### PR TITLE
Fix no matches for deployment in extensions/v1beta1 issue

### DIFF
--- a/example/deployment.yaml
+++ b/example/deployment.yaml
@@ -1,13 +1,16 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: etcd-operator
 spec:
+  selector:
+    matchLabels:
+      app: etcd-operator
   replicas: 1
   template:
     metadata:
       labels:
-        name: etcd-operator
+        app: etcd-operator
     spec:
       containers:
       - name: etcd-operator


### PR DESCRIPTION
As deployment in the extensions/v1beta1 was deprecated from
K8S 1.16, so change the deployment to suit K8S 1.16 version
and later.

Ref: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/


Please read https://github.com/coreos/etcd-operator/blob/master/CONTRIBUTING.md#contribution-flow
